### PR TITLE
Test enhancement

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,10 +10,18 @@ branches:
 matrix:
   include:
     -
-      php: 7.1
+      php: 7.4
       env: 'HIGHEST_LOWEST="update"'
     -
+      php: 7.3
+    -
+      php: 7.2
+    -
+      php: 7.1
+    -
       php: 7.0.11
+    -
+      php: 5.6
     -
       php: 5.5
       env: 'HIGHEST_LOWEST="update --prefer-lowest"'

--- a/composer.json
+++ b/composer.json
@@ -15,17 +15,17 @@
     },
     "autoload-dev":{
         "psr-4":{
-            "Consolidation\\Comments\\":"tests/src"
+            "Consolidation\\Comments\\":"tests"
         }
     },
     "require": {
         "php": ">=5.5.0"
     },
     "require-dev": {
-        "phpunit/phpunit": "^4.8",
+        "phpunit/phpunit": "^4.8.36",
         "symfony/yaml": "^3.1",
         "phpunit/php-code-coverage": "~2|~4",
-        "satooshi/php-coveralls": "^1.0",
+        "php-coveralls/php-coveralls": "^1.0",
         "squizlabs/php_codesniffer": "^2.8"
     },
     "scripts": {

--- a/tests/TestComments.php
+++ b/tests/TestComments.php
@@ -1,7 +1,9 @@
 <?php
 namespace Consolidation\Comments;
 
-class TestComments extends \PHPUnit_Framework_TestCase
+use PHPUnit\Framework\TestCase;
+
+class TestComments extends TestCase
 {
     function commentTestData()
     {

--- a/tests/TestYamlComments.php
+++ b/tests/TestYamlComments.php
@@ -2,8 +2,9 @@
 namespace Consolidation\Comments;
 
 use Symfony\Component\Yaml\Yaml;
+use PHPUnit\Framework\TestCase;
 
-class TestYamlComments extends \PHPUnit_Framework_TestCase
+class TestYamlComments extends TestCase
 {
     function setUp()
     {


### PR DESCRIPTION
# Changed log
- To be compatible with future `PHPUnit` version, using the `PHPUnit\Framework\TestCase` namespace  instead. And changing into `^4.8.36` version on `composer.json`.
- Add other `php-7.x` versions and `php-5.6` version tests during Travis CI build.
- The `satooshi/php-coveralls` package is deprecated, and using the `php-coveralls/php-coveralls` package instead.